### PR TITLE
Github linking regex to allow punctuation

### DIFF
--- a/handlers/message_handler.py
+++ b/handlers/message_handler.py
@@ -33,7 +33,7 @@ class MessageHandler():
 		if await self.handle_cmd(message):
 			return
 
-		matches = re.findall(r"(?<!<)(\w+)?#(\d+)($|\s)", message.content)
+		matches = re.findall(r"(?<!<)(\w+)?#(\d+)($|\s|[^\w])", message.content)
 		if len(matches):
 			print("[%s]" % (message.channel), message.content)
 		for match in matches:


### PR DESCRIPTION
Will allow punctuation at the end of a GitHub issue tag, ex `#123?` or `#321!` will now match